### PR TITLE
set api-version to 1.13 in plugin.yml

### DIFF
--- a/resources/plugin.yml
+++ b/resources/plugin.yml
@@ -1,6 +1,7 @@
 name: CountryOnJoin
 main: sososlik.countryonjoin.Plugin
 version: 1.2.0
+api-version: 1.13
 author: "Sososlik (sososlik@outlook.com)"
 description: "Mentions the country from wich the player joins the game. Adds placeholders and a command to get the country information."
 website: https://www.spigotmc.org/resources/country-on-join-bukkit-edition.34275/


### PR DESCRIPTION
When plugin is loaded there is a warning about loading an legacy plugin. The reason for that is that there is no api-version specified in plugin.yml file.